### PR TITLE
bump Flask from 1.1.2 to 2.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.0.3
 google-api-python-client==2.27.0
 google-cloud-pubsub==2.8.0
 oauth2client==4.1.3


### PR DESCRIPTION
As described in the issue https://github.com/doitintl/iris3/issues/14 upgrading Flask to 2.0+ fixes `ImportError: cannot import name 'json' from 'itsdangerous'`, among many other fixes and improvements.

Flask changes: https://flask.palletsprojects.com/en/2.0.x/changes/