### PR TITLE
update pyyaml to 6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml==6.0
+pyyaml==6.0.1
 Flask==2.2.3
 Werkzeug==2.2.2
 google-api-python-client==2.84.0


### PR DESCRIPTION
Cython 3.0 change seems to have broken pyyaml 6.0 in most instances.  An upgrade to 6.0.1 fixes the installation issue.

https://github.com/yaml/pyyaml/blob/main/CHANGES#L16